### PR TITLE
codeclimate

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -1,0 +1,2 @@
+languages:
+  JavaScript: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,4 +6,4 @@ node_js:
 script:
   - npm test
 after_script:
-  - npm run coveralls
+  - npm run codeclimate

--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -72,7 +72,7 @@ module.exports = function(grunt) {
       },
       lcov: {
         options: {
-          captureFile: 'coverage/results.info',
+          captureFile: 'coverage/lcov.info',
           quiet: true,
           reporter: 'mocha-lcov-reporter'
         },
@@ -118,7 +118,6 @@ module.exports = function(grunt) {
   grunt.loadNpmTasks('grunt-contrib-copy');
   grunt.loadNpmTasks('grunt-contrib-uglify');
   grunt.loadNpmTasks('grunt-contrib-watch');
-  grunt.loadNpmTasks('grunt-coveralls');
   grunt.loadNpmTasks('grunt-eslint');
   grunt.loadNpmTasks('grunt-jsdoc');
   grunt.loadNpmTasks('grunt-mocha-test');

--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@
 extensible characters.
 
 [![Build Status](https://travis-ci.org/neocotic/phony.js.svg?branch=develop)][1]
-[![Coverage Status](https://coveralls.io/repos/neocotic/phony.js/badge.svg)][10]
+[![Code Climate](https://codeclimate.com/github/neocotic/phony.js/badges/gpa.svg)][10]
+[![Test Coverage](https://codeclimate.com/github/neocotic/phony.js/badges/coverage.svg)][11]
 [![Dependency Status](https://gemnasium.com/neocotic/phony.js.svg)][4]
 [![Built with Grunt](https://cdn.gruntjs.com/builtwith.png)][5]
 
@@ -169,4 +170,5 @@ See [LICENSE.md][9] for more information on our MIT license.
 [7]: https://github.com/neocotic/phony.js/blob/master/AUTHORS.md
 [8]: https://github.com/neocotic/phony.js/blob/master/CONTRIBUTING.md
 [9]: https://github.com/neocotic/phony.js/blob/master/LICENSE.md
-[10]: https://coveralls.io/r/neocotic/phony.js
+[10]: https://codeclimate.com/github/neocotic/phony.js
+[11]: https://codeclimate.com/github/neocotic/phony.js/coverage

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "url": "git://github.com/neocotic/phony.js.git"
   },
   "devDependencies": {
+    "codeclimate-test-reporter": "^0.0.4",
     "expect.js": "^0.3.1",
     "grunt": "^0.4.5",
     "grunt-blanket": "^0.0.8",
@@ -39,7 +40,6 @@
     "grunt-contrib-copy": "^0.8.0",
     "grunt-contrib-uglify": "^0.9.1",
     "grunt-contrib-watch": "^0.6.1",
-    "grunt-coveralls": "^1.0.0",
     "grunt-eslint": "^13.0.0",
     "grunt-jsdoc": "^0.6.7",
     "grunt-mocha-test": "^0.12.7",
@@ -49,7 +49,7 @@
   },
   "main": "src/phony.js",
   "scripts": {
-    "coveralls": "grunt coveralls",
+    "codeclimate": "codeclimate < coverage/lcov.info",
     "test": "grunt test"
   },
   "config": {


### PR DESCRIPTION
Switching from simple code coverage from [coveralls.io](https://coveralls.io) to code coverage and analysis from [codeclimate](https://codeclimate.com).