### PR TITLE
Added very simple CLI

### DIFF
--- a/Gruntfile.js
+++ b/Gruntfile.js
@@ -37,6 +37,7 @@ module.exports = function(grunt) {
     eslint: {
       target: [
         'Gruntfile.js',
+        'bin/phony',
         'lib/**/*.js',
         'test/**/*.js'
       ]

--- a/README.md
+++ b/README.md
@@ -15,7 +15,8 @@ extensible characters.
 
 [![Build Status](https://img.shields.io/travis/neocotic/phony.js/develop.svg?style=flat-square)][1]
 [![Test Coverage](https://img.shields.io/coveralls/neocotic/phony.js/develop.svg?style=flat-square)][10]
-[![Dependency Status](https://img.shields.io/david/dev/neocotic/phony.js.svg?style=flat-square)][4]
+[![Dependency Status](https://img.shields.io/david/neocotic/phony.js.svg?style=flat-square)][4]
+[![Dev Dependency Status](https://img.shields.io/david/dev/neocotic/phony.js.svg?style=flat-square)][11]
 [![License](https://img.shields.io/github/license/neocotic/phony.js.svg?style=flat-square)][9]
 [![Release](https://img.shields.io/github/tag/neocotic/phony.js.svg?style=flat-square)][5]
 
@@ -29,8 +30,6 @@ $ npm install node-phony
 # OR; for the browser:
 $ bower install phony
 ```
-
-This library has no dependencies on any other library.
 
 ## Usage
 
@@ -51,6 +50,28 @@ It's important to note that the same options should be used in order for bidirec
 these strings are used to build regular expressions (or can be regular expressions), so it's recommended to
 familiarized yourself with the usage of the options before change them, just so you know on which you need to escape
 any `RegExp` special characters.
+
+### Command Line
+
+If you installed `node-phony` globally using npm you can use this libraries built-in command line interface:
+
+```
+Usage: phony [options] [command]
+
+
+Commands:
+
+  from <message>  translates the message to the phonetic alphabet
+  to <message>    translates the message from the phonetic alphabet
+
+Options:
+
+  -h, --help                     output usage information
+  -V, --version                  output the version number
+  -a, --alphabet [name]          name of the alphabet to be used
+  -l, --letter-splitter [value]  sequence of characters to split letters
+  -w, --word-splitter [value]    sequence of characters to split words
+```
 
 ### `to(message[, options])`
 
@@ -192,3 +213,4 @@ See [LICENSE.md][9] for more information on our MIT license.
 [8]: https://github.com/neocotic/phony.js/blob/master/CONTRIBUTING.md
 [9]: https://github.com/neocotic/phony.js/blob/master/LICENSE.md
 [10]: https://coveralls.io/r/neocotic/phony.js
+[11]: https://david-dm.org/neocotic/phony.js#info=devDependencies

--- a/bin/.eslintrc
+++ b/bin/.eslintrc
@@ -1,0 +1,5 @@
+{
+  "rules": {
+    "strict": [2, "global"]
+  }
+}

--- a/bin/phony
+++ b/bin/phony
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+
+'use strict';
+
+var program = require('commander');
+var os = require('os');
+
+var phony = require('../lib/phony');
+
+program
+  .version(phony.VERSION)
+  .option('-a, --alphabet [name]', 'name of the alphabet to be used', phony.defaults.alphabet)
+  .option('-l, --letter-splitter [value]', 'sequence of characters to split letters', phony.defaults.letterSplitter)
+  .option('-w, --word-splitter [value]', 'sequence of characters to split words', phony.defaults.wordSplitter);
+
+function translate(methodName) {
+  return function(message) {
+    var options = {
+      alphabet: program.alphabet,
+      letterSplitter: program.letterSplitter,
+      wordSplitter: program.wordSplitter
+    };
+
+    process.stdout.write(phony[methodName](message, options) + os.EOL);
+  };
+}
+
+program
+  .command('from <message>')
+  .description('translates the message to the phonetic alphabet')
+  .action(translate('from'));
+
+program
+  .command('to <message>')
+  .description('translates the message from the phonetic alphabet')
+  .action(translate('to'));
+
+program.parse(process.argv);
+
+if (!process.argv.slice(2).length) {
+  program.outputHelp();
+}

--- a/package.json
+++ b/package.json
@@ -30,6 +30,9 @@
     "type": "git",
     "url": "git://github.com/neocotic/phony.js.git"
   },
+  "dependencies": {
+    "commander": "^2.8.1"
+  },
   "devDependencies": {
     "expect.js": "^0.3.1",
     "grunt": "^0.4.5",
@@ -48,6 +51,9 @@
     "travis-cov": "^0.2.5"
   },
   "main": "lib/phony.js",
+  "bin": {
+    "phony": "bin/phony"
+  },
   "scripts": {
     "coveralls": "grunt coveralls",
     "test": "grunt test"


### PR DESCRIPTION
I've added a very basic CLI for #8 which exposes the main methods along with the appropriate options. The usage is as follows:

```
Usage: phony [options] [command]


Commands:

  from <message>  translates the message to the phonetic alphabet
  to <message>    translates the message from the phonetic alphabet

Options:

  -h, --help                     output usage information
  -V, --version                  output the version number
  -a, --alphabet [name]          name of the alphabet to be used
  -l, --letter-splitter [value]  sequence of characters to split letters
  -w, --word-splitter [value]    sequence of characters to split words
```